### PR TITLE
add support for running dependency resolution in parallel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.maven>2.2.1</version.maven>
-    <version.jdk>1.4</version.jdk>
+    <version.jdk>1.5</version.jdk>
   </properties>
   <dependencies>
     <dependency>
@@ -95,6 +95,11 @@
         <groupId>com.pyx4j</groupId>
         <artifactId>maven-plugin-log4j</artifactId>
         <version>1.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>19.0</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Added support to run dependency resolution in parrallel. Can be disabled by passing -Ddependency.version.check.useParallelDepResolution=false in mvn command line (true by default)

Running on presto-main at presto project gives about 4x perf improvement
Without parallel dependency resolution:

```
mvn validate -pl presto-main -Dbuildtime.output.log=true  -Ddependency.version.check.useParallelDepResolution=false
...
[INFO] --- maven-dependency-versions-check-plugin:2.0.3-SNAPSHOT:check (default) @ presto-main ---
[INFO] Checking dependency versions
[INFO] Using parallel dependency resolution: false
...
[INFO]   maven-dependency-versions-check-plugin:check (default) ... [8.796s]
```

Running with parallel resolution:

```
mvn validate -pl presto-main -Dbuildtime.output.log=true 
...
[INFO] --- maven-dependency-versions-check-plugin:2.0.3-SNAPSHOT:check (default) @ presto-main ---
[INFO] Checking dependency versions
[INFO] Using parallel dependency resolution: true
...
[INFO]   maven-dependency-versions-check-plugin:check (default) ... [2.100s]
```
